### PR TITLE
added `service` property to indicate a RUC page covers only a specific service

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ desirable for Ineo or other portals. It should be exact name of the group as it 
 
 ```markdown
 ---
-identifier: tool
+identifier: tool-identifier-from-tools-clariah-nl
 title: Tool
 ---
 ```
@@ -99,6 +99,18 @@ metadata of one specific tool in the group/suite with the group as a whole. This
 to still describe a whole tool suite in Ineo, but picks one of the tools in the suite as being its representative and have its metadata prominently features.
 
 Note that neither `identifier` nor `group` uniquely identify a markdown file, they may be reused from multiple files and are merely intended to link to <https://tools.clariah.nl>.
+
+It is possible that a Rich Content description is focussed on certain Software-as-a-Service whereas the codemeta is more focussed on the underlying software. In such cases it can happen that the codemeta representation lists multiple services/deployments of that software (expressed via the `targetProduct` property in the codemeta JSON-LD), whereas in the Rich User Content you may want to only cover a particular one. An example of this is <https://tools.clariah.nl/#corpus-frontend> . To constrain a rich user content page to a single service, add the following to the YAML frontmatter:
+
+```markdown
+---
+identifier: tool-identifier-from-tools-clariah-nl
+title: Service name
+service: https://some.domain/service
+---
+```
+
+The URL to the service must exactly match the `url` property of the `targetProduct` in the metadata. This `service` option should be interpreted as a signal to the consolidation pipeline merging rich content and metadata that only this single service should be expressed (and none of the others, if any). Moreover, it indicates that expressing metadata of the service (the matching object under `targetProduct`) has precedence over expressing metadata of the source code, in situations where there might otherwise be a tie.
 
 The following Ineo-specific metadata can be added:
 


### PR DESCRIPTION
Dit is een voorstel voor aanpassing van de specificatie om het mogelijk te maken dat één rich user content pagina wijst naar één bepaalde service behorende bij een codemeta descriptie (in tegenstelling tot een verwijzijng tot alle services). Dit is een complexe situatie veroorzaakt door mogelijk verschil in granulariteit tussen de tool discovery pipeline en Ineo, en ook omdat Ineo momenteel van één grote "Go" knop uitgaat per pagina.

*(zie de tekst in de commit voor het precieze voorstel)*


@inge1211 Nog wat extra toelichting; https://tools.clariah.nl/corpus-frontend/ is hier momenteel het beste voorbeeld van, als je in de codemeta.json kijkt zie je daar `targetProduct` met drie services (met `@type: schema:WebApplication`). Wat ik voorstel is dat als men bv een OpenSoNaR RUC pagina wil maken, vanuit gebruikersperspectief een legitieme insteek, dat deze dan `identifier: corpus-frontend` en `service: https://opensonar.ivdnt.org` heeft. Dan weet je in je pipeline dat je moet matchen met het `targetProduct` met die `url` (en de andere kan negeren). Die `url` wordt dan ook dé URL die voor de Ineo "go" knop geldt en heeft voorrang boven the `url` op het hogere niveau (die naar de website van de software an sich wijst, niet noodzakelijk de service), en voorang op de de `codeRepository`.

In de webinterface van https://tools.clariah.nl is nu overigens ook al de mogelijkheid om de tools meer op zo'n "service-centric" manier te visualiseren via de [services only](https://tools.clariah.nl/services/) link.

Lijkt jullie dit een goede oplossing?